### PR TITLE
Add example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # No-empty-html-text
 
 ## What is it?
+
 This is a simple rule for the [`elm-review`](https://package.elm-lang.org/packages/jfmengels/elm-review/latest/) tool that will flag the use of the `Html.text` function as a mean to show nothing. It is quite often the case that we see the following pattern in elm code:
 
 ```elm
@@ -9,7 +10,6 @@ if a then
 else
   text ""
 ```
-
 
 However, there is the quite nice [`elm-community/html-extra`](https://package.elm-lang.org/packages/elm-community/html-extra/latest/) package that provide utility functions to "replace" those `text ""` by an alias [`nothing`](https://package.elm-lang.org/packages/elm-community/html-extra/latest/Html-Extra#nothing) or by some other utility functions (e.g [`viewIf`](https://package.elm-lang.org/packages/elm-community/html-extra/latest/Html-Extra#viewIf), [`viewMaybe`](https://package.elm-lang.org/packages/elm-community/html-extra/latest/Html-Extra#viewMaybe), ...)
 
@@ -24,3 +24,15 @@ However, there is the quite nice [`elm-community/html-extra`](https://package.el
 - if you do not want to use `html-extra`.
 - if you do not want to setup `elm-review`.
 - ...
+
+## Example configuration
+
+```elm
+import NoEmptyText
+import Review.Rule exposing (Rule)
+
+config : List Rule
+config =
+  [ NoEmptyText.rule
+  ]
+```

--- a/example/elm.json
+++ b/example/elm.json
@@ -1,0 +1,37 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "jfmengels/elm-review": "2.2.0",
+            "leojpod/review-no-empty-html-text": "1.0.0"
+        },
+        "indirect": {
+            "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/project-metadata-utils": "1.0.1",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "elm-community/json-extra": "4.3.0",
+            "elm-community/list-extra": "8.2.4",
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-hex": "1.0.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3",
+            "stil4m/elm-syntax": "7.1.3",
+            "stil4m/structured-writer": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2"
+        },
+        "indirect": {}
+    }
+}

--- a/example/src/ReviewConfig.elm
+++ b/example/src/ReviewConfig.elm
@@ -1,0 +1,21 @@
+module ReviewConfig exposing (config)
+
+{-| Do not rename the ReviewConfig module or the config function, because
+`elm-review` will look for these.
+
+To add packages that contain rules, add them to this review project using
+
+    `elm install author/packagename`
+
+when inside the directory containing this file.
+
+-}
+
+import NoEmptyText
+import Review.Rule exposing (Rule)
+
+
+config : List Rule
+config =
+    [ NoEmptyText.rule
+    ]


### PR DESCRIPTION
Add an `example/` config ready for [elm-review@2.3.0](https://github.com/jfmengels/node-elm-review/releases/tag/v2.3.0-beta.1)'s upcoming `--template` feature. Also adds example configuration to the `README` so that people can quickly discover how to use the rule.